### PR TITLE
Fixed date parsing by using a regex

### DIFF
--- a/chrome/chrall/chrall_general.js
+++ b/chrome/chrall/chrall_general.js
@@ -98,7 +98,7 @@ chrall.updateTroll = function(){
 // Renvoie 0 si pas trouvé
 chrall.findMHSeconds = function(){
 	var date = $("#hserveur");
-	return date.length > 0 ? Date.parse(date.text().replace(/ GMT\+\d{4}\]/, "")).getTime() / 1000 : 0;
+	return date.length > 0 ? Date.parse(date.text().replace(/ GMT|\]/g, "")).getTime() / 1000 : 0;
 }
 
 // Retourne combien de PX seront obtenu lors du kill du niveau en parametre

--- a/chrome/chrall/chrall_general.js
+++ b/chrome/chrall/chrall_general.js
@@ -98,7 +98,7 @@ chrall.updateTroll = function(){
 // Renvoie 0 si pas trouvé
 chrall.findMHSeconds = function(){
 	var date = $("#hserveur");
-	return date.length > 0 ? Date.parse(date.text().replace(" GMT+0100]", "")).getTime() / 1000 : 0;
+	return date.length > 0 ? Date.parse(date.text().replace(/ GMT\+\d{4}\]/, "")).getTime() / 1000 : 0;
 }
 
 // Retourne combien de PX seront obtenu lors du kill du niveau en parametre


### PR DESCRIPTION
In daylight saving time, the timezone offset is different (+0200) so the replace was failing.
With using a regex, the replace will always work no matter the timezone offset.